### PR TITLE
Add license files to Nuget packages (OSK-9)

### DIFF
--- a/.github/workflows/publish-packages-workflow.yml
+++ b/.github/workflows/publish-packages-workflow.yml
@@ -13,7 +13,7 @@ jobs:
   publish-nuget:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Get the version
         id: get_version
         run: echo "PACKAGE_VERSION=${GITHUB_REF/refs\/tags\//}" >> "$GITHUB_OUTPUT" 

--- a/src/OSK.Serialization.Abstractions.Binary/OSK.Serialization.Abstractions.Binary.csproj
+++ b/src/OSK.Serialization.Abstractions.Binary/OSK.Serialization.Abstractions.Binary.csproj
@@ -10,6 +10,10 @@
 		<Title>OSK.Serialization.Abstractions.Binary</Title>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\OSK.Serialization.Abstractions\OSK.Serialization.Abstractions.csproj" />
 	</ItemGroup>

--- a/src/OSK.Serialization.Abstractions.Json/OSK.Serialization.Abstractions.Json.csproj
+++ b/src/OSK.Serialization.Abstractions.Json/OSK.Serialization.Abstractions.Json.csproj
@@ -9,6 +9,10 @@
 		<Title>OSK.Serialization.Abstractions.Json</Title>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\OSK.Serialization.Abstractions\OSK.Serialization.Abstractions.csproj" />
 	</ItemGroup>

--- a/src/OSK.Serialization.Abstractions.Yaml/OSK.Serialization.Abstractions.Yaml.csproj
+++ b/src/OSK.Serialization.Abstractions.Yaml/OSK.Serialization.Abstractions.Yaml.csproj
@@ -9,6 +9,10 @@
 		<Title>OSK.Serialization.Abstractions.Yaml</Title>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
 	<ItemGroup>
 		<ProjectReference Include="..\OSK.Serialization.Abstractions\OSK.Serialization.Abstractions.csproj" />
 	</ItemGroup>

--- a/src/OSK.Serialization.Abstractions/OSK.Serialization.Abstractions.csproj
+++ b/src/OSK.Serialization.Abstractions/OSK.Serialization.Abstractions.csproj
@@ -10,4 +10,8 @@
 		<Title>OSK.Serialization.Abstractions</Title>
 	</PropertyGroup>
 
+	<PropertyGroup>
+		<PackageLicenseExpression>MIT</PackageLicenseExpression>
+	</PropertyGroup>
+
 </Project>


### PR DESCRIPTION
Motivation
----
Fix warnings from builds relating to missing license

Modifications
----
* Add license to projects

Result
----
Nuget warnings should disappear

Fixes #9